### PR TITLE
Fix README usage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ dotnet build
 Navigate to the build output directory and run the tool:
 
 ```bash
-cd src/azdo-scanner/bin/Debug/net6.0
+cd src/azdo-scanner/bin/Debug/net9.0
 ./azdo-scanner [command] [options]
 ```
 


### PR DESCRIPTION
## Summary
- update net6.0 folder path in Usage section

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68418b42d9a483278ae8ff004e4699f8