### PR TITLE
Add CI workflow for tests and tool packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test tests/AzdoScanner.Tests/AzdoScanner.Tests.csproj --configuration Release --no-build
+      - name: Pack global tool
+        run: |
+          dotnet pack src/azdo-scanner/azdo-scanner.csproj --configuration Release --no-build --output ./artifacts
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: azdo-scanner-nupkg
+          path: ./artifacts/*.nupkg

--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+dotnet-install.sh
+packages-microsoft-prod.deb

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To use this tool, you need:
 
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed and configured
 - [Azure DevOps CLI extension](https://docs.microsoft.com/en-us/azure/devops/cli/) installed
+- [.NET SDK 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed (see below)
 - Authentication to your Azure DevOps organization (via `az login` and `az devops configure`)
 
 ## Installation
@@ -28,7 +29,28 @@ Clone this repository and build the project:
 ```bash
 git clone https://github.com/Geertvdc/azdo-scanner.git
 cd azdo-scanner
+# Install the .NET 9 SDK if you don't already have it
+curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+bash dotnet-install.sh --channel 9.0 --install-dir $HOME/.dotnet --no-path
+export PATH="$HOME/.dotnet:$PATH"
 dotnet build
+```
+
+### Running Tests
+
+Execute the unit tests with:
+
+```bash
+dotnet test
+```
+
+### Building the Global Tool
+
+Create a NuGet package that can be installed as a .NET tool:
+
+```bash
+dotnet pack -c Release
+dotnet tool install --global --add-source ./src/azdo-scanner/bin/Release azdo-scanner
 ```
 
 ## Usage

--- a/src/azdo-scanner/azdo-scanner.csproj
+++ b/src/azdo-scanner/azdo-scanner.csproj
@@ -6,6 +6,11 @@
     <RootNamespace>azdo_scanner</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>azdo-scanner</ToolCommandName>
+    <PackageId>azdo-scanner</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>azdo-scanner</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AzdoScanner.Tests/AzdoScanner.Tests.csproj
+++ b/tests/AzdoScanner.Tests/AzdoScanner.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\azdo-scanner\azdo-scanner.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AzdoScanner.Tests/OrganizationResolverTests.cs
+++ b/tests/AzdoScanner.Tests/OrganizationResolverTests.cs
@@ -1,0 +1,56 @@
+using AzdoScanner.Core;
+
+namespace AzdoScanner.Tests;
+
+public class FakeProcessRunner : IProcessRunner
+{
+    public ProcessResult Result { get; set; } = new();
+    public string? LastFileName { get; private set; }
+    public string? LastArguments { get; private set; }
+
+    public ProcessResult Run(string fileName, string arguments, int timeoutMs = 10000)
+    {
+        LastFileName = fileName;
+        LastArguments = arguments;
+        return Result;
+    }
+}
+
+public class OrganizationResolverTests
+{
+    [Fact]
+    public void ReturnsExplicitOrganizationUnchanged()
+    {
+        var runner = new FakeProcessRunner();
+        var org = "https://dev.azure.com/myorg";
+        var result = OrganizationResolver.Resolve(org, runner);
+        Assert.Equal(org, result);
+        Assert.Null(runner.LastFileName); // no call when org provided
+    }
+
+    [Fact]
+    public void RetrievesOrganizationFromAzConfig()
+    {
+        var runner = new FakeProcessRunner();
+        runner.Result = new ProcessResult
+        {
+            ExitCode = 0,
+            Output = "{\"organization\":\"dev.azure.com/mockorg\"}"
+        };
+        var result = OrganizationResolver.Resolve(null, runner);
+        Assert.Equal("https://dev.azure.com/mockorg", result);
+        Assert.Equal("az", runner.LastFileName);
+        Assert.Contains("devops configure --list", runner.LastArguments);
+    }
+
+    [Theory]
+    [InlineData("myorg", "https://dev.azure.com/myorg")]
+    [InlineData("dev.azure.com/myorg", "https://dev.azure.com/myorg")]
+    [InlineData("https://dev.azure.com/myorg/", "https://dev.azure.com/myorg/")]
+    public void NormalizesOrganizationUrls(string input, string expected)
+    {
+        var runner = new FakeProcessRunner();
+        var result = OrganizationResolver.Resolve(input, runner);
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build, test and pack the tool
- enable packing `azdo-scanner` as a .NET global tool
- document how to pack and install the tool locally

## Testing
- `dotnet test tests/AzdoScanner.Tests/AzdoScanner.Tests.csproj`
- `dotnet pack src/azdo-scanner/azdo-scanner.csproj -c Release --output ./temp_nupkgs`


------
https://chatgpt.com/codex/tasks/task_e_68418fb5b16c832796b37ac2f59d5ae4